### PR TITLE
Add support for package alias

### DIFF
--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -104,9 +104,6 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         return finish();
     };
 
-    const supportsPackageAliases = packageManager =>
-        packageManager === 'npm' || packageManager === 'yarn';
-
     options.packageDir = options.packageDir || findup(packageJsonName);
     if (!options.packageDir) {
         return missingPackageJson();
@@ -208,10 +205,7 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         const depJson = require(depJsonPath);
 
         // Support package aliases
-        if (
-            supportsPackageAliases(options.packageManager) &&
-            /npm:(.+)@(.+)/.test(versionString)
-        ) {
+        if (/npm:(.+)@(.+)/.test(versionString)) {
             const [, depName, version] = versionString.match(/npm:(.+)@(.+)/);
 
             versionString = version;


### PR DESCRIPTION
Same changes as this other PR, except with the package manager check removed as requested in the PR comments.
https://github.com/mgol/check-dependencies/pull/45